### PR TITLE
refactor import script

### DIFF
--- a/pg_nearest_city/scripts/voronoi_generator.py
+++ b/pg_nearest_city/scripts/voronoi_generator.py
@@ -14,11 +14,11 @@ import os
 import shutil
 import sys
 import tempfile
+import urllib.request
+import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
-import urllib.request
-import zipfile
 
 import psycopg
 from psycopg.rows import dict_row


### PR DESCRIPTION
This refactors the import script in a few ways:

* Replaces the call to `awk` via `subprocess` with Python's native `csv` library
* During import to Postgres, if the user specified a specific country, it filters during the import instead of deleting non-matches after importing every country
* For development purposes, allows the user to specify an existing zipfile to avoid re-downloading from GeoNames
* Various exception handling tightening and refactoring to support the above

Open to criticism and requests for changes!